### PR TITLE
Changes for Rasterio 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - libgdal-dev
 python:
   - "2.7"
+  - "3.5"
 before_install:
   - pip install -U pip
   - pip install wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,7 @@ before_install:
   - pip install -U pip
   - pip install wheel
 install:
-  - if [[ $RASTERIO == 'master' ]]; then pip install numpy cython; pip install git+https://github.com/mapbox/rasterio.git; fi
-  - if [[ $RASTERIO == 'recent' ]]; then pip wheel rasterio; pip install rasterio; fi
-  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; fi
+  - if [[ $RASTERIO == 'master' ]]; then pip install numpy cython; pip install git+https://github.com/mapbox/rasterio.git; elif [[ $RASTERIO == 'recent' ]]; then pip wheel rasterio; pip install rasterio; else pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; fi
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ before_install:
   - pip install -U pip
   - pip install wheel
 install:
-  - if [[ $RASTERIO == 'master' ]]; then pip install git+https://github.com/mapbox/rasterio.git; fi
-  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; fi
+  - if [[ $RASTERIO == 'master' ]]; then pip install numpy cython; pip install git+https://github.com/mapbox/rasterio.git; fi
+  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; else; pip wheel rasterio; pip install rasterio; fi
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,29 @@ addons:
     - libgdal1h
     - gdal-bin
     - libgdal-dev
-python:
-  - "2.7"
-  - "3.5"
+matrix:
+  include:
+    # For each python version, we test
+    # rasterio 0.36, the most recent release and master
+    - python: 2.7
+      env: RASTERIO=0.36
+    - python: 2.7
+      env: RASTERIO=recent
+    - python: 2.7
+      env: RASTERIO=master
+    - python: 3.5
+      env: RASTERIO=0.36
+    - python: 3.5
+      env: RASTERIO=recent
+    - python: 3.5
+      env: RASTERIO=master
+
 before_install:
   - pip install -U pip
   - pip install wheel
 install:
+  - if [[ $RASTERIO == 'master' ]]; then pip install git+https://github.com/mapbox/rasterio.git; fi
+  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; fi
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ before_install:
   - pip install wheel
 install:
   - if [[ $RASTERIO == 'master' ]]; then pip install numpy cython; pip install git+https://github.com/mapbox/rasterio.git; fi
-  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; else; pip wheel rasterio; pip install rasterio; fi
+  - if [[ $RASTERIO == 'recent' ]]; then pip wheel rasterio; pip install rasterio; fi
+  - if [[ $RASTERIO != 'recent' ]]; then pip wheel "rasterio==$RASTERIO"; pip install "rasterio==$RASTERIO"; fi
   - pip install -r requirements-dev.txt
   - pip install -e .
   - pip install coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rio merge-rgba
 
-[![Build Status](https://magnum.travis-ci.com/mapbox/rio-merge-rgba.svg?token=pyxzY34Uw5pJTCJpD6xs&branch=master)](https://magnum.travis-ci.com/mapbox/rio-merge-rgba)
+[![Build Status](https://travis-ci.org/mapbox/rio-merge-rgba.svg)](https://travis-ci.org/mapbox/rio-merge-rgba.svg)
 
 A `rio merge` alternative optimized for large RGBA tifs
 


### PR DESCRIPTION
Resolves #5 
No changes for the sake of python 3 were required but there were several Rasterio 1.0 issues. Of course, we don't have a 1.0 release yet... @sgillies any thoughts on how we should add master/pre-releases of Rasterio to the build matrix.