### PR TITLE
upgrade to rasterio 1.0beta and fix test for compression

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='rio-merge-rgba',
       zip_safe=False,
       install_requires=[
           'click',
-          'rasterio>=1.0a12'
+          'rasterio>=1.0b1'
       ],
       extras_require={
           'test': ['pytest', 'pytest-cov'],

--- a/tests/test_rio_merge_rgba.py
+++ b/tests/test_rio_merge_rgba.py
@@ -249,5 +249,4 @@ def test_opts(test_data_dir_3):
         assert out.profile['tiled'] == True
         assert out.profile['blockxsize'] == 16
         assert out.profile['blockysize'] == 16
-        assert out.profile['compress'] == "none"
         assert out.compression is None


### PR DESCRIPTION
The `compress` key does not exist in the dataset profile as of rasterio 1.0b